### PR TITLE
refactor(room): use roomId that comes from params

### DIFF
--- a/backend/src/external/controllers/room.controller.ts
+++ b/backend/src/external/controllers/room.controller.ts
@@ -58,7 +58,7 @@ export class RoomController {
     }
 
     this.socketMessageService.server.emit(
-      `room/${room.getValue().id}`,
+      `room/${params.roomId}`,
       JSON.stringify({
         type: 'associate_user_in_room',
         ...room.getValue(),


### PR DESCRIPTION
Utiliza o id que vem do params para o uso no socket em vez de utilizar uma função do getValues.